### PR TITLE
Add sprunge.us and paste.rs providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# *paperplanes*.nvim
+# _paperplanes_.nvim
 
-![paperplanes Logo](images/logo.png) 
+![paperplanes Logo](images/logo.png)
 
 Post selections or buffers to online paste bins. Save the URL to a register, or
 dont.
@@ -27,7 +27,7 @@ require("paperplanes").setup({
 ```
 
 - `register` - any valid register name or false
-- `provider` - "0x0.st", "ix.io" or "dpaste.org"
+- `provider` - "0x0.st", "ix.io", "dpaste.org", "sprunge.us" or "paste.rs"
 
 > Note: http://0x0.st seems to be the fastest responding provider.
 
@@ -61,14 +61,16 @@ Functions to not automatically print the url or set any registers.
 
 ## Providers
 
-*paperplanes* supports the following providers, see sites for TOS and
+_paperplanes_ supports the following providers, see sites for TOS and
 features.
 
 - http://0x0.st
 - http://ix.io
 - http://dpaste.org
+- http://sprunge.us
+- https://paste.rs
 
 To create a new provider, see [`:h paperplanes`](doc/paperplanes.txt) and
 `fnl/paperplanes/providers/*.fnl`.
 
-*paperplanes* is not affiliated with any provider in any manner.
+_paperplanes_ is not affiliated with any provider in any manner.

--- a/doc/paperplanes.txt
+++ b/doc/paperplanes.txt
@@ -46,7 +46,7 @@ Setup ~
   })
 
 - `register` - any valid register name or false
-- `provider` - "0x0.st", "ix.io" or "dpaste.org"
+- `provider` - "0x0.st", "ix.io", "dpaste.org", "sprunge.us" or "paste.rs"
 
 See also |paperplanes-providers|.
 
@@ -113,6 +113,8 @@ Providers ~
 - http://0x0.st
 - http://ix.io
 - http://dpaste.org
+- http://sprunge.us
+- https://paste.rs
 
 To add your own provider, you must return a table with two functions,
 `post-string` and `post-file`.

--- a/fnl/paperplanes/providers/init.fnl
+++ b/fnl/paperplanes/providers/init.fnl
@@ -1,3 +1,5 @@
 {:dpaste.org (require :paperplanes.providers.dpasteorg)
  :ix.io (require :paperplanes.providers.ixio)
- :0x0.st (require :paperplanes.providers.0x0st)}
+ :0x0.st (require :paperplanes.providers.0x0st)
+ :sprunge.us (require :paperplanes.providers.sprungeus)
+ :paste.rs (require :paperplanes.providers.pasters)}

--- a/fnl/paperplanes/providers/pasters.fnl
+++ b/fnl/paperplanes/providers/pasters.fnl
@@ -1,0 +1,24 @@
+(local {: set-field} (require :paperplanes.util.providers))
+
+(fn make [content-arg meta]
+  (local args (doto []
+                    (table.insert :--data-binary)
+                    (table.insert content-arg)
+                    (table.insert "https://paste.rs")))
+
+  (fn after [response status]
+    (match status
+      ;;returns url as "url\n" so we need to strip the new line
+      201 (string.match response "^(https?://.*)\n")
+      _ (values nil response)))
+
+  (values args after))
+
+(fn post-string [string meta]
+  (make (.. string) meta))
+
+(fn post-file [file meta]
+  (make (.. "@" file) meta))
+
+{: post-string
+ : post-file}

--- a/fnl/paperplanes/providers/sprungeus.fnl
+++ b/fnl/paperplanes/providers/sprungeus.fnl
@@ -1,0 +1,23 @@
+(local {: set-field} (require :paperplanes.util.providers))
+
+(fn make [content-arg meta]
+  (local args (doto []
+                    (set-field :sprunge content-arg)
+                    (table.insert "http://sprunge.us")))
+
+  (fn after [response status]
+    (match status
+      ;;returns url as "url\n" so we need to strip the new line
+      200 (string.match response "^(http://.*)\n")
+      _ (values nil response)))
+
+  (values args after))
+
+(fn post-string [string meta]
+  (make (.. string) meta))
+
+(fn post-file [file meta]
+  (make (.. "<" file) meta))
+
+{: post-string
+ : post-file}


### PR DESCRIPTION
I added a couple of providers more:
- sprunge.us
- paste.rs

I prefer paste.rs (take a look if you don't know it)

I changed the docs too but I didn't included the compiled lua files because they change all the variable names, maybe it's better if you do it as yourself :)